### PR TITLE
onChange syntax update for macOS14+

### DIFF
--- a/Flowmodachi/FlowmodachiVisualView.swift
+++ b/Flowmodachi/FlowmodachiVisualView.swift
@@ -68,11 +68,11 @@ struct FlowmodachiVisualView: View {
                 isPulsing = true
             }
         }
-        .onChange(of: elapsedSeconds) { _ in
+        .onChange(of: elapsedSeconds) {
             updateStage()
         }
-        .onChange(of: isSleeping) { newValue in
-            isPulsing = newValue
+        .onChange(of: isSleeping) {
+            isPulsing = isSleeping
         }
     }
 


### PR DESCRIPTION
Fixing a warning prompt on xCode stating: 
'onChange(of:perform:)' was deprecated in macOS 14.0: Use onChange with a two or zero parameter action closure instead. 
Change made:

```swift
.onChange(of: elapsedSeconds) {
    updateStage()
}
.onChange(of: isSleeping) {
    isPulsing = isSleeping
}

``` 