### PR TITLE
debug mode for break timer 15secs

### DIFF
--- a/Flowmodachi/MenuBarContentView.swift
+++ b/Flowmodachi/MenuBarContentView.swift
@@ -98,13 +98,18 @@ struct MenuBarContentView: View {
     // MARK: - Break Functions
 
     private func suggestBreak() {
+        #if DEBUG
+        let suggestedBreak = 0.25 // 15 seconds in debug mode (0.25 min)
+        #else
         let minutes = elapsedSeconds / 60
         let suggestedBreak = minutes >= 120 ? 30 : min(max(Int(Double(minutes) * 0.2), 5), 20)
+        #endif
 
-        breakTotalDuration = suggestedBreak * 60
+        breakTotalDuration = Int(suggestedBreak * 60)
         breakSecondsRemaining = breakTotalDuration
         startBreak()
     }
+
 
     private func startBreak() {
         isFlowing = false
@@ -115,6 +120,8 @@ struct MenuBarContentView: View {
                 endBreak()
             }
         }
+        print("Break started for \(breakTotalDuration) seconds")
+
     }
 
     private func endBreak() {


### PR DESCRIPTION
Added debug mode for breaktimer sequence to be set for 15 seconds to see full view. According to docs the debug mode won't apply during production so were keeping the debug mode intact so we don't have to modify the OG logic. Also, added a print statement for xCode terminal to see if debug mode works.
```swift
private func suggestBreak() {
        #if DEBUG
        let suggestedBreak = 0.25 // 15 seconds in debug mode (0.25 min)
        #else
        let minutes = elapsedSeconds / 60
        let suggestedBreak = minutes >= 120 ? 30 : min(max(Int(Double(minutes) * 0.2), 5), 20)
        #endif

        breakTotalDuration = Int(suggestedBreak * 60)
        breakSecondsRemaining = breakTotalDuration
        startBreak()
    }


    private func startBreak() {
        isFlowing = false
        isOnBreak = true
        breakTimer = Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true) { _ in
            breakSecondsRemaining -= 1
            if breakSecondsRemaining <= 0 {
                endBreak()
            }
        }
        print("Break started for \(breakTotalDuration) seconds")

    }
``` 