### PR TITLE
FlowSession added. Flow metrics stored

### DIFF
--- a/Flowmodachi/FlowSession.swift
+++ b/Flowmodachi/FlowSession.swift
@@ -1,0 +1,8 @@
+import Foundation
+
+struct FlowSession: Codable, Identifiable {
+    let id: UUID
+    let startDate: Date
+    let duration: Int // in seconds
+}
+

--- a/Flowmodachi/MenuBarContentView.swift
+++ b/Flowmodachi/MenuBarContentView.swift
@@ -10,12 +10,24 @@ struct MenuBarContentView: View {
     @State private var breakSecondsRemaining = 0
     @State private var breakTotalDuration = 0
     @State private var breakTimer: Timer?
+    @StateObject private var sessionManager = SessionManager()
+
 
     var body: some View {
         VStack(spacing: 16) {
             Text("Flowmodachi")
                 .font(.title2)
                 .fontWeight(.semibold)
+        
+            VStack(spacing: 4) {
+                Text("🕒 Today: \(sessionManager.totalMinutesToday()) min")
+                    .font(.caption)
+                    .foregroundColor(.gray)
+                Text("🔥 Streak: \(sessionManager.longestStreak()) day\(sessionManager.longestStreak() == 1 ? "" : "s")")
+                    .font(.caption)
+                    .foregroundColor(.gray)
+            }
+
 
             // 🌕 Unified Visual: Evolving creature OR sleeping moon
             FlowmodachiVisualView(
@@ -131,6 +143,8 @@ struct MenuBarContentView: View {
         breakSecondsRemaining = 0
         elapsedSeconds = 0
         playBreakEndSound()
+        sessionManager.addSession(duration: elapsedSeconds)
+
     }
 
     // MARK: - Sound

--- a/Flowmodachi/SessionManager.swift
+++ b/Flowmodachi/SessionManager.swift
@@ -1,0 +1,58 @@
+import Foundation
+
+class SessionManager: ObservableObject {
+    @Published private(set) var sessions: [FlowSession] = []
+
+    private let storageKey = "FlowmodachiSessions"
+
+    init() {
+        loadSessions()
+    }
+
+    func addSession(duration: Int) {
+        let newSession = FlowSession(id: UUID(), startDate: Date(), duration: duration)
+        sessions.append(newSession)
+        saveSessions()
+    }
+
+    func totalMinutesToday() -> Int {
+        let calendar = Calendar.current
+        let todaySessions = sessions.filter {
+            calendar.isDateInToday($0.startDate)
+        }
+        let totalSeconds = todaySessions.map { $0.duration }.reduce(0, +)
+        return totalSeconds / 60
+    }
+
+    func longestStreak() -> Int {
+        let sortedDates = Set(sessions.map { Calendar.current.startOfDay(for: $0.startDate) }).sorted(by: >)
+
+        guard !sortedDates.isEmpty else { return 0 }
+
+        var streak = 1
+        var current = sortedDates[0]
+
+        for date in sortedDates.dropFirst() {
+            if Calendar.current.date(byAdding: .day, value: -1, to: current) == date {
+                streak += 1
+                current = date
+            } else {
+                break
+            }
+        }
+        return streak
+    }
+
+    private func saveSessions() {
+        if let data = try? JSONEncoder().encode(sessions) {
+            UserDefaults.standard.set(data, forKey: storageKey)
+        }
+    }
+
+    private func loadSessions() {
+        if let data = UserDefaults.standard.data(forKey: storageKey),
+           let saved = try? JSONDecoder().decode([FlowSession].self, from: data) {
+            sessions = saved
+        }
+    }
+}


### PR DESCRIPTION
Added:

1. Flow sessions saved after each break
2. Stats on total focus time today
3. A running streak of focused days
4. Data stored between app launches




