### PR TITLE
Refactor

### DIFF
--- a/Flowmodachi/DebugToolsView.swift
+++ b/Flowmodachi/DebugToolsView.swift
@@ -3,11 +3,14 @@ import SwiftUI
 struct DebugToolsView: View {
     @AppStorage("debugMoodOverride") private var debugMoodOverride: String = "none"
     @AppStorage("debugMissedYesterday") private var debugMissedYesterday: Bool = false
-
+    
+    @EnvironmentObject var sessionManager: SessionManager
+    
     var body: some View {
         #if DEBUG
         DisclosureGroup("🧪 Dev Tools") {
-            VStack(alignment: .leading, spacing: 8) {
+            VStack(alignment: .leading, spacing: 10) {
+                // Picker to override mood
                 Picker("Mood", selection: $debugMoodOverride) {
                     Text("None").tag("none")
                     Text("Sleepy").tag("sleepy")
@@ -16,7 +19,16 @@ struct DebugToolsView: View {
                 }
                 .pickerStyle(.segmented)
 
+                // Toggle missed yesterday debug flag
                 Toggle("Missed Yesterday", isOn: $debugMissedYesterday)
+
+                // 🔄 Clear all session data
+                Button("Clear All Sessions") {
+                    sessionManager.clearAllSessions()
+                    print("🗑 Cleared all flow sessions.")
+                }
+                .foregroundColor(.red)
+                .font(.caption)
             }
             .padding(8)
             .background(Color.gray.opacity(0.05))


### PR DESCRIPTION
Lots done on the PR:

✅ Refactored SessionManager to use computed properties:
- currentStreak, longestStreak, totalSessions

✅ Automatically records sessions after threshold met (5 sec debug / 5 min prod)

✅ Prevents duplicate sessions per day

✅ Cleaned up MenuBarContentView to reference computed properties directly

✅ Added calculateMood() helper for Flowmodachi mood logic

✅ Created DebugToolsView to simulate:
- Mood override
- Missed yesterday toggle

✅ Replaced deprecated .onChange(of:) usage (macOS 14+)

✅ Smoothed out creature transition and mood icon logic


