### PR TITLE
persistence flow bug fix

### DIFF
--- a/Flowmodachi/SessionPersistenceHelper.swift
+++ b/Flowmodachi/SessionPersistenceHelper.swift
@@ -4,18 +4,20 @@ enum SessionPersistenceHelper {
     private static let persistenceKey = "FlowSessionState"
     private static let maxResumeDelay: TimeInterval = 600 // 10 minutes
 
-    static func save(elapsedSeconds: Int) {
-        let state: [String: Double] = [
+    /// Save current flow session state to UserDefaults.
+    static func saveSession(elapsedSeconds: Int) {
+        let state: [String: Any] = [
             "timestamp": Date().timeIntervalSince1970,
-            "elapsed": Double(elapsedSeconds)
+            "elapsed": elapsedSeconds
         ]
         UserDefaults.standard.set(state, forKey: persistenceKey)
     }
 
+    /// Attempt to restore session from saved state (if not expired).
     static func restoreSession() -> Int? {
-        guard let saved = UserDefaults.standard.dictionary(forKey: persistenceKey) as? [String: Double],
-              let timestamp = saved["timestamp"],
-              let savedElapsed = saved["elapsed"],
+        guard let saved = UserDefaults.standard.dictionary(forKey: persistenceKey),
+              let timestamp = saved["timestamp"] as? TimeInterval,
+              let savedElapsed = saved["elapsed"] as? Double,
               savedElapsed > 0 else {
             return nil
         }
@@ -31,6 +33,7 @@ enum SessionPersistenceHelper {
         }
     }
 
+    /// Clear any previously saved session state.
     static func clearSession() {
         UserDefaults.standard.removeObject(forKey: persistenceKey)
     }


### PR DESCRIPTION
Bug: App saves once at the start of flow, not continuously. So when the app quits, it doesn't have an updated value.

```swift
.onAppear {
    if resumeOnLaunch {
        DispatchQueue.main.async {
            if let restored = SessionPersistenceHelper.restoreSession() {
                elapsedSeconds = restored
                startTimer()
            }
        }
    }
}

``` 

Using DispatchQueue.main.async ensures state updates don’t conflict with SwiftUI lifecycle.

