### PR TITLE
View Extension

### DIFF
--- a/Flowmodachi/MoodCalculator.swift
+++ b/Flowmodachi/MoodCalculator.swift
@@ -1,0 +1,17 @@
+import SwiftUI
+
+struct MoodCalculator {
+    static func compute(from sessionManager: SessionManager, debugOverride: String, debugMissed: Bool) -> CreatureMood {
+        #if DEBUG
+        switch debugOverride {
+        case "sleepy": return .sleepy
+        case "happy": return .happy
+        case "neutral": return .neutral
+        default: break
+        }
+        #endif
+
+        return sessionManager.calculateMood(debugMissedYesterday: debugMissed)
+    }
+}
+

--- a/Flowmodachi/SessionMetricsView.swift
+++ b/Flowmodachi/SessionMetricsView.swift
@@ -1,0 +1,17 @@
+import SwiftUI
+
+struct SessionMetricsView: View {
+    @EnvironmentObject var sessionManager: SessionManager
+
+    var body: some View {
+        VStack(spacing: 4) {
+            Text("🕒 Today: \(sessionManager.totalMinutesToday()) min")
+                .font(.caption)
+                .foregroundColor(.gray)
+
+            Text("🔥 Streak: \(sessionManager.longestStreak) day\(sessionManager.longestStreak == 1 ? "" : "s")")
+                .font(.caption)
+                .foregroundColor(.gray)
+        }
+    }
+}

--- a/Flowmodachi/View+LifecycleHelpers.swift
+++ b/Flowmodachi/View+LifecycleHelpers.swift
@@ -1,0 +1,42 @@
+import SwiftUI
+
+// MARK: - View Extension
+
+extension View {
+    /// Attaches session lifecycle tracking (flow & break) and scene phase handling to any view.
+    func trackSessionLifecycleChanges(using flowEngine: FlowEngine) -> some View {
+        self
+            .onChange(of: flowEngine.elapsedSeconds) {
+                flowEngine.recordSessionIfEligible()
+            }
+            .onChange(of: flowEngine.isFlowing) { _, newValue in
+                flowEngine.handleFlowPersistence(isFlowing: newValue)
+            }
+            .onChange(of: flowEngine.isOnBreak) { _, newValue in
+                flowEngine.handleBreakPersistence(isOnBreak: newValue)
+            }
+            .modifier(ScenePhasePersistenceModifier(flowEngine: flowEngine)) // ✅ fixed parameter name
+    }
+}
+
+// MARK: - Scene Phase Modifier
+
+private struct ScenePhasePersistenceModifier: ViewModifier {
+    @Environment(\.scenePhase) private var scenePhase
+    let flowEngine: FlowEngine
+
+    func body(content: Content) -> some View {
+        content
+            .task(id: scenePhase) { // ✅ modern and safe in macOS 14+
+                switch scenePhase {
+                case .background:
+                    flowEngine.handleFlowPersistence(isFlowing: flowEngine.isFlowing)
+                    flowEngine.handleBreakPersistence(isOnBreak: flowEngine.isOnBreak)
+                case .active:
+                    flowEngine.restoreSessionIfAvailable()
+                default:
+                    break
+                }
+            }
+    }
+}


### PR DESCRIPTION
---

###  Refactor: Abstracted Session & Break Lifecycle Handling into View Extension

**Summary of Changes:**
- Added a new `View+LifecycleHelpers.swift` file to encapsulate view-level tracking logic.
- Introduced `trackSessionLifecycleChanges(using:)` as a composable `.modifier` extension.
- Replaced explicit `.onChange` calls in `MenuBarContentView` with the new extension for clarity and maintainability.
- Implemented `ScenePhasePersistenceModifier` using `.task(id:)` to observe `scenePhase` changes (macOS 14+ compatible).
  - Automatically restores flow/break timers on app activation.
  - Persists session and break states on backgrounding.
- Reduced cognitive overhead in `MenuBarContentView` by centralizing reactive lifecycle responsibilities.

**Benefits:**
- More declarative and testable lifecycle behavior.
- Prepares architecture for scalable view tracking (e.g., app analytics, onboarding flags, etc.).
- Cleaner `MenuBarContentView` focused on layout, not persistence logic.

---